### PR TITLE
fix: gap on loading and lock files on gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,10 @@ yarn-error.log*
 .env*.local
 .env
 
+# lock files
+pnpm-lock.yaml
+yarn.lock
+
 # vercel
 .vercel
 

--- a/app/issues/list/loading.tsx
+++ b/app/issues/list/loading.tsx
@@ -2,14 +2,14 @@
 // antes de carregar a página dessa pasta!
 
 import { Skeleton } from "@/app/components";
-import { Table } from "@radix-ui/themes";
+import { Flex, Table } from "@radix-ui/themes";
 import IssueActions from "./IssueActions";
 
 function LoadingIssuesPage() {
   const issues = [1, 2, 3, 4, 5];
 
   return (
-    <div>
+    <Flex direction="column" gap="3">
       <IssueActions />
       <Table.Root variant="surface">
         <Table.Header>
@@ -42,7 +42,7 @@ function LoadingIssuesPage() {
           ))}
         </Table.Body>
       </Table.Root>
-    </div>
+    </Flex>
   );
 }
 


### PR DESCRIPTION
### 🎯 Objectives
Fix gap on loading in the issues list.

---
### 📝 Changes
- Fixes the gap between the issues list actions and the list itself;
- adds lock files to `gitignore`.

---
### 📷 Media
![image](https://github.com/mwilsonoliveira/issue-tracker/assets/62682824/5a40716b-1bee-48b6-9232-ae5974ed7b58)